### PR TITLE
chore: use GITHUB_TOKEN instead of PAT token in `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
            artifacts: "iso/*.iso,iso/MD5SUMS"
-           token: ${{ secrets.SECRET_TOKEN }}
+           token: ${{ secrets.GITHUB_TOKEN }}
            tag: ${{ steps.date.outputs.date }} 
         
            


### PR DESCRIPTION
WIth your current method, you need to create a token and with `Error undefined: Parameter token or opts.auth is required` but I realized that you can use GitHub's builtin token, GITHUB_TOKEN instead. This also saves you the time to not have to update your PAT token.